### PR TITLE
Finish News page and homepage previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@ Visit **[biomodsquad.org](https://biomodsquad.org)** 🚀
 
 _Built with [Lab Website Template](https://greene-lab.gitbook.io/lab-website-template-docs)_
 
+## Adding news
+
+Create a Markdown file named `YYYY-MM-DD-short-title.md` in `_posts`. The first
+paragraph becomes the preview blurb automatically. A post can also set
+`description` for a custom blurb and `thumbnail` for a preview image that differs
+from the full-page `image`.
+
+```yaml
+---
+title: Example news title
+author: Your Name
+image: images/news/example-hero.jpg
+thumbnail: images/news/example-thumbnail.jpg
+tags:
+  - award
+  - research
+---
+```
+
+The three newest posts appear on the homepage automatically. The News page lists
+all posts newest-first and groups them by year.

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -51,6 +51,7 @@
       subtitle=d.subtitle
       tags=d.tags
       text=d.text
+      thumbnail=d.thumbnail
       title=d.title
       tooltip=d.tooltip
       type=d.type

--- a/_includes/news-list.html
+++ b/_includes/news-list.html
@@ -1,0 +1,29 @@
+{% assign posts = site.posts | sort: "date" | reverse %}
+
+{% if posts.size > 0 %}
+  {% if include.limit %}
+    <div class="news-list">
+      {% for post in posts limit: include.limit %}
+        {% include post-excerpt.html lookup=post.slug %}
+      {% endfor %}
+    </div>
+  {% else %}
+    {% assign years = posts
+      | group_by_exp: "post", "post.date | date: '%Y'"
+      | sort: "name"
+      | reverse
+    %}
+
+    <div class="news-list">
+      {% for year in years %}
+        <h2 id="{{ year.name }}">{{ year.name }}</h2>
+        {% assign year_posts = year.items | sort: "date" | reverse %}
+        {% for post in year_posts %}
+          {% include post-excerpt.html lookup=post.slug %}
+        {% endfor %}
+      {% endfor %}
+    </div>
+  {% endif %}
+{% else %}
+  <p class="center">{{ include.empty | default: "News and updates will appear here soon." }}</p>
+{% endif %}

--- a/_includes/post-excerpt.html
+++ b/_includes/post-excerpt.html
@@ -12,7 +12,8 @@
   <div class="post-excerpt">
     {% assign url = post.url | relative_url | uri_escape %}
     {% assign title = post.title %}
-    {% assign image = post.image | relative_url | uri_escape %}
+    {% assign image = post.thumbnail | default: post.image %}
+    {% assign image = image | relative_url | uri_escape %}
 
     {% if image %}
       <a
@@ -40,12 +41,18 @@
         tags=post.tags
       %}
 
-      {% assign excerpt = post.content
+      {% assign marked_excerpt = post.content
         | default: ""
         | regex_scan: "<!-- excerpt start -->(.*)<!-- excerpt end -->", true
+      %}
+      {% assign excerpt = post.description
+        | default: marked_excerpt
         | default: post.excerpt
         | default: ""
         | strip_html
+        | strip_newlines
+        | regex_strip
+        | truncatewords: 45
       %}
       {% assign search = post.content
         | strip_html

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,22 +2,30 @@
 layout: default
 ---
 
-{% include section.html background=page.image %}
+{% if page.image %}
+  {% include section.html background=page.image %}
+{% endif %}
 
-<h1 class="center">{{ page.title }}</h1>
+<article class="news-article">
+  <header class="news-article-header">
+    <h1 class="center">{{ page.title }}</h1>
 
-{%
-  include post-info.html
-  author=page.author
-  member=page.member
-  published=page.date
-  updated=page.last_modified_at
-  tags=page.tags
-%}
+    {%
+      include post-info.html
+      author=page.author
+      member=page.member
+      published=page.date
+      updated=page.last_modified_at
+      tags=page.tags
+    %}
+  </header>
 
-{% include section.html %}
+  {% include section.html %}
 
-{{ content }}
+  <div class="news-article-content">
+    {{ content }}
+  </div>
+</article>
 
 {% include section.html %}
 

--- a/_styles/news.scss
+++ b/_styles/news.scss
@@ -1,0 +1,18 @@
+---
+---
+
+.news-list > h2 {
+  margin-top: 40px;
+}
+
+.news-list > h2:first-child {
+  margin-top: 0;
+}
+
+.news-article-header .post-info {
+  justify-content: center;
+}
+
+.news-article-content {
+  margin-inline: auto;
+}

--- a/_styles/post-excerpt.scss
+++ b/_styles/post-excerpt.scss
@@ -29,7 +29,7 @@ $wrap: 800px;
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
 }
 
 .post-excerpt-text {
@@ -46,6 +46,7 @@ $wrap: 800px;
 
 .post-excerpt-text > a:first-child {
   width: 100%;
+  font-size: 1.15rem;
   font-weight: var(--semi-bold);
 }
 

--- a/index.md
+++ b/index.md
@@ -109,3 +109,15 @@ Our team is highly collaborative and strives to find creative solutions to chall
 
 {% include section.html %}
 
+## Latest News
+
+{% include news-list.html limit=3 empty="The latest BioModSquad news will appear here soon." %}
+
+{%
+  include button.html
+  link="news"
+  text="View all news"
+  icon="fa-solid fa-arrow-right"
+  flip=true
+  style="bare"
+%}

--- a/news/index.md
+++ b/news/index.md
@@ -17,4 +17,4 @@ Updates, announcements, and recent events from the BioModSquad.
 
 {% include search-info.html %}
 
-{% include list.html data="posts" component="post-excerpt" %}
+{% include news-list.html %}


### PR DESCRIPTION
## Summary
- add reusable chronological News lists and the newest three posts to the homepage
- support separate preview thumbnails and concise first-paragraph blurbs
- improve full article markup and document the news-post authoring format
- add a graceful empty state until the first real post is published

## Validation
- GitHub Actions build and link checks