### PR TITLE
Add Georgia Tech move news post

### DIFF
--- a/_posts/2025-01-01-biomodsquad-moves-to-georgia-tech.md
+++ b/_posts/2025-01-01-biomodsquad-moves-to-georgia-tech.md
@@ -1,0 +1,15 @@
+---
+title: BioModSquad Moves to Georgia Tech
+author: chris-kieslich
+image: images/biomodsquad_2_26oct23.jpg
+thumbnail: images/biomodsquad_2_26oct23.jpg
+tags:
+  - announcement
+  - lab news
+---
+
+On January 1, 2025, the Biomolecular Systems Modeling and Design Group—BioModSquad—officially moved from Auburn University to the Georgia Institute of Technology.
+
+The move marks an exciting new chapter for Dr. Chris Kieslich and the group. BioModSquad is now based in the Wallace H. Coulter Department of Biomedical Engineering at Georgia Tech and Emory University, where we will continue developing computational approaches for biomolecular modeling, machine learning, optimization, and therapeutic design.
+
+We are grateful to Auburn University, our colleagues, collaborators, and students for their support and contributions to the group’s growth. We look forward to building new collaborations at Georgia Tech while continuing to work with partners at Auburn and across the broader research community.


### PR DESCRIPTION
## Summary
- publish the first BioModSquad news post announcing the January 1, 2025 move from Auburn University to Georgia Tech
- use the existing 2023 BioModSquad group photograph for the article and preview card

## Validation
- GitHub Actions build and link checks