### PR TITLE
Fit MISTIC schematic within Tool card

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -2,6 +2,7 @@
   subtitle: Feature selection and explanation for support vector machines
   group: research
   image: images/mistic-framework.png
+  style: contained
   link: https://biomodsquad.org/interpretable-explainable-svms/index.html
   description: Python framework for building interpretable support vector machine ensembles, with reproducible cross-validation, kernel-aware feature selection, perturbation ranking, calibrated probability analysis, and local integrated-gradient explanations in one workflow.
   tags:

--- a/_styles/card.scss
+++ b/_styles/card.scss
@@ -27,6 +27,20 @@
   // box-shadow: var(--shadow);
 }
 
+.card[data-style="contained"] .card-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+}
+
+.card[data-style="contained"] .card-image img {
+  width: 70%;
+  aspect-ratio: auto;
+  object-fit: contain;
+}
+
 .card-text {
   display: inline-flex;
   justify-content: flex-start;


### PR DESCRIPTION
Centers the full MISTIC schematic at 70% width in its Tool-card image area so the wide diagram is no longer cropped. Other Tool thumbnails are unchanged.