### PR TITLE
Enlarge MISTIC Tool thumbnail

### DIFF
--- a/_styles/card.scss
+++ b/_styles/card.scss
@@ -36,7 +36,7 @@
 }
 
 .card[data-style="contained"] .card-image img {
-  width: 70%;
+  width: 80.5%;
   aspect-ratio: auto;
   object-fit: contain;
 }


### PR DESCRIPTION
Increases the contained MISTIC schematic from 70% to 80.5% width, making it 15% larger while retaining the complete image.