### PR TITLE
Build site from latest main branch

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout main branch contents
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch || github.ref_name }}
 
       - name: Install Ruby packages
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
- update live site builds to check out the latest  branch tip
- prevent stale Pages deploys when citation updates commit back to  during the workflow

## Testing
- reviewed the  workflow chain and confirmed  runs after 
- verified the build step previously checked out the triggering SHA instead of the latest branch state